### PR TITLE
Simplify the project configuration

### DIFF
--- a/Chapter05-jwtpropandot/jwtprop/src/test/resources/project-defaults.yml
+++ b/Chapter05-jwtpropandot/jwtprop/src/test/resources/project-defaults.yml
@@ -1,22 +1,9 @@
 swarm:
   microprofile:
-    jwt:
+    realm: Packt
+    roles:
+      file: roles.properties  
+    jwtauth:
       token:
         signer-pub-key: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqOAjDHZU7FisNb9srcITQOpptmT06fbgHh9KiESS/FZJNsIyPs2Hok9qY9++N6boilCBxKnBsznprwcvQzMETkeGK/9EiRyWEyq4n8NRM4hoPsV42UYFV+8zWokwIjwVXtF5ZBM8IVxo70IloVnjIDoxA4ESGVG0WfgeRFEXAknMBnvcTzGuQdGwGdp/eKa32XMYyT+/X+urOHA8wHU8RNjcEVJht1H083wu26rsLdDLJeA3R1wd9OKzUrdTaKFWcJ1/l2F+ekNkZyi5E9M0JE6V1ujCr2KNNkH9OhopmqNCEddDAzksnF/cEn1jkgdjA/kFzWz3GiQgNQr4CGEczQIDAQAB
         issued-by: "http://io.packt.jwt"
-  security:
-    security-domains:
-      Packt:
-        jaspi-authentication:
-          login-module-stacks:
-            roles-lm-stack:
-              login-modules:
-                - login-module: rm
-                  code: org.wildfly.swarm.microprofile.jwtauth.deployment.auth.jaas.JWTLoginModule
-                  flag: required
-          auth-modules:
-            http:
-              code: org.wildfly.extension.undertow.security.jaspi.modules.HTTPSchemeServerAuthModule
-              module: org.wildfly.extension.undertow
-              flag: required
-              login-module-stack-ref: roles-lm-stack


### PR DESCRIPTION
Thorntail 2.4.0.Final does not yet support 'jwt' configuration path for the new 'realm' and 'roles.file' properties but will from 2.4.1.Final